### PR TITLE
fix: arrange pages artifact under v-diff subpath

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -40,10 +40,15 @@ jobs:
         working-directory: packages/wtool-vdiff
         run: pnpm run build && pnpm run build:site
 
+      - name: Arrange Pages structure
+        run: |
+          mkdir -p _site/v-diff
+          cp -r packages/wtool-vdiff/site/dist/. _site/v-diff/
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: packages/wtool-vdiff/site/dist
+          path: _site
 
   deploy:
     needs: build


### PR DESCRIPTION
Fix GitHub Pages 404: move build output into `v-diff/` subdirectory so assets are served at `/web-toolkits/v-diff/assets/`